### PR TITLE
Optionally only return REDACTED when decrypting pkcs7.

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
@@ -20,6 +20,9 @@ class Hiera
             :subject => { :desc => "Subject to use for certificate when creating keys",
                           :type => :string,
                           :default => "/" },
+            :redacted => { :desc => "Only return '!!!REDACTED!!!' when decrypting",
+                           :type => :bool,
+                           :default => false},
           }
 
           self.tag = "PKCS7"
@@ -41,6 +44,7 @@ class Hiera
 
             public_key = self.option :public_key
             private_key = self.option :private_key
+            redacted = self.option :redacted
             raise StandardError, "pkcs7_public_key is not defined" unless public_key
             raise StandardError, "pkcs7_private_key is not defined" unless private_key
 
@@ -50,8 +54,12 @@ class Hiera
             public_key_pem = File.read public_key
             public_key_x509 = OpenSSL::X509::Certificate.new( public_key_pem )
 
-            pkcs7 = OpenSSL::PKCS7.new( ciphertext )
-            pkcs7.decrypt(private_key_rsa, public_key_x509)
+            if redacted
+              "!!!REDACTED!!!"
+            else
+              pkcs7 = OpenSSL::PKCS7.new( ciphertext )
+              pkcs7.decrypt(private_key_rsa, public_key_x509)
+            end
 
           end
 


### PR DESCRIPTION
This is intended more as a feature request or request for comment than and actual pull request.

We use hiera with our PE installation, and the eyaml backend to encrypt all passwords and keys etc.
I'd like to be able to test a full set of production puppet code with production hiera data, minus the production passwords, without having to maintain another copy of the hiera data.


Thoughts?