### PR TITLE
Fix versions numbers in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,18 @@
 Change log for hiera-eyaml
 ==========================
 
-2.06
-----
+2.0.6
+-----
 
  - #131 - Fix another EDITOR bug (#130) that could erase command line flags to the specified editor (@elyscape)
 
-2.05
-----
+2.0.5
+-----
 
  - #128 - Fix a bug (#127) that caused `eyaml edit` to break when `$EDITOR` was a command on PATH rather than a path to a command (@elyscape)
 
-2.04
-----
+2.0.4
+-----
 
  - Add change log
  - #118 - Some initial support for spaces in filenames (primarily targeted at windows platforms) (@elyscape)
@@ -22,5 +22,5 @@ Change log for hiera-eyaml
  - #90, #121, #122 - Add preamble in edit mode to make it easier to remember how to edit (@sihil)
  - #96, #111, #116 - Various updates to docs
 
-2.03
-----
+2.0.3
+-----


### PR DESCRIPTION
This is a minor thing but the version numbers in the changelog were incorrect (e.g. 2.06 vs. 2.0.6).  This fixes them.