### PR TITLE
Add tool to make annotated git tags from changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,18 @@
 Change log for hiera-eyaml
 ==========================
 
-2.06
-----
+2.0.6
+-----
 
  - #131 - Fix another EDITOR bug (#130) that could erase command line flags to the specified editor (@elyscape)
 
-2.05
-----
+2.0.5
+-----
 
  - #128 - Fix a bug (#127) that caused `eyaml edit` to break when `$EDITOR` was a command on PATH rather than a path to a command (@elyscape)
 
-2.04
-----
+2.0.4
+-----
 
  - Add change log
  - #118 - Some initial support for spaces in filenames (primarily targeted at windows platforms) (@elyscape)
@@ -22,5 +22,5 @@ Change log for hiera-eyaml
  - #90, #121, #122 - Add preamble in edit mode to make it easier to remember how to edit (@sihil)
  - #96, #111, #116 - Various updates to docs
 
-2.03
-----
+2.0.3
+-----

--- a/tools/git_tag_release.rb
+++ b/tools/git_tag_release.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.9')
+  $stderr.puts "This script requires Ruby >= 1.9"
+  exit 1
+end
+
+require 'open3'
+result = Open3.capture3('git rev-parse --show-toplevel')
+unless result[2].exitstatus == 0
+  $stderr.puts "You do not appear to be in a git repository. This script must be run from inside a git repository."
+  exit 2
+end
+filename = result[0].lines.first.chomp + '/CHANGES.md'
+unless File.exist?(filename)
+  $stderr.puts "CHANGES.md not found. Please ensure that CHANGES.md exists."
+  exit 3
+end
+contents = IO.read(filename)
+
+lines = contents.lines.drop(3).map(&:chomp).reject(&:empty?)
+versions = Hash.new
+currentversion = nil
+versions[nil] = []
+lines.each_with_index do |line, index|
+  if line =~ /\A-+\z/
+    versions[currentversion].pop
+    currentversion = lines[index-1]
+    versions[currentversion] = []
+  else
+    versions[currentversion] << line
+  end
+end
+versions.delete(nil)
+
+def prompt(*args)
+  print(*args)
+  gets.chomp
+end
+
+newest = versions.first[0]
+version = prompt "Version [#{newest}]: "
+version = newest if version.empty?
+
+unless versions[version]
+  $stderr.puts "Version #{version} is invalid. Valid versions are: #{versions.keys.join(', ')}"
+  exit 4
+end
+
+tagname = "v#{version}"
+
+
+
+result = Open3.capture3("git rev-parse #{tagname}")
+if result[2].exitstatus == 0
+  $stderr.puts "Tag #{tagname} already exists."
+  exit 5
+end
+
+commit = prompt "Commit: "
+
+result = Open3.capture3("git --no-pager log -1 #{commit} --format='%ci'")
+unless result[2].exitstatus == 0
+  $stderr.puts "Commit '#{commit}' is not valid."
+  exit result[2].exitstatus
+end
+commitdate = result[0].lines.first.chomp
+
+def word_wrap(line, width)
+  first_prefix = line.match(/([ -]*)/)[1]
+  prefix = ' ' * first_prefix.size
+  real_width = width - (prefix.size * 2)
+  line[prefix.size..-1].gsub(/(^)?(.{1,#{real_width}})(?: +|$)/) { |s| $1 ? "#{first_prefix}#{s}\n" : "#{prefix}#{s}\n" }
+end
+
+require 'tempfile'
+begin
+  tf = Tempfile.new('tag-message')
+  tf.puts "Version #{version} release"
+  tf.puts ""
+  tf.puts "Changes:"
+  versions[version].each do |line|
+    tf.puts word_wrap(line, 80)
+  end
+  tf.flush
+
+  result = Open3.capture3({'GIT_COMMITTER_DATE' => commitdate}, "git tag -a #{tagname} #{commit} -F #{tf.path}")
+  $stderr.puts result[1]
+  if result[2].exitstatus == 0
+    system "git --no-pager show #{tagname} --no-patch"
+    puts ""
+    puts "Tag created. Please push to GitHub with `git push origin #{tagname}`."
+  end
+  exit result[2].exitstatus
+ensure
+  tf.close!
+end


### PR DESCRIPTION
This simplifies #138 and makes tagging releases simpler in the future by parsing the changelog and creating an annotated git tag based on its contents for the specified version on the specified commit.  ~~It relies on #140, so merge that first.~~ Might as well subsume PR into this one anyway.  Closed the other.