### PR TITLE
Travis improvements: lock cucumber gem so we can build on Ruby <1.9.3, add newer Ruby, disable email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_install:
   - sudo apt-get install expect
 script:
   bundle exec cucumber -f progress
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - "1.8.7-p374"
   - "1.9.2"
   - "1.9.3"
+  - "2.0.0"
+  - "2.1.5"
 before_install:
   - sudo apt-get update
   - sudo apt-get install expect

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ gem 'highline', '~> 1.6.19'
 gem 'trollop', '~> 2.0'
 
 group :development do
-  gem "aruba"
+  gem "aruba", '~> 0.6.2'
+  gem "cucumber", '~> 1.1'
+  gem "rspec-expectations", '~> 3.1.0'
   gem "hiera-eyaml-plaintext"
   gem "puppet"
 end


### PR DESCRIPTION
This fixes Travis builds on old versions of Ruby, adds automated testing for current versions of Ruby, and disables email notifications of build success/failure.