### PR TITLE
Fix decrypted content leaking from eyaml edit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_install:
   - sudo apt-get install expect
 script:
   bundle exec cucumber -f progress
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - "1.8.7-p374"
   - "1.9.2"
   - "1.9.3"
+  - "2.0.0"
+  - "2.1.5"
 before_install:
   - sudo apt-get update
   - sudo apt-get install expect

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ gem 'highline', '~> 1.6.19'
 gem 'trollop', '~> 2.0'
 
 group :development do
-  gem "aruba"
+  gem "aruba", '~> 0.6.2'
+  gem "cucumber", '~> 1.1'
+  gem "rspec-expectations", '~> 3.1.0'
   gem "hiera-eyaml-plaintext"
   gem "puppet"
 end

--- a/features/edit.feature
+++ b/features/edit.feature
@@ -30,6 +30,12 @@ Feature: eyaml editing
     And the output should match /\s+key6: DEC\(\d+\)::PKCS7\[value6\]\!/
     And the output should match /multi_encryption: DEC\(\d+\)::PLAINTEXT\[jammy\]\! DEC\(\d+\)::PKCS7\[dodger\]!/
 
+  Scenario: decrypting a eyaml file should create a temporary file
+    Given my EDITOR is set to "/usr/bin/env true"
+    When I run `bash -c 'cp test_input.yaml test_input.eyaml'`
+    When I run `eyaml edit -v test_input.eyaml`
+    Then the stderr should contain "Wrote temporary file"
+
   Scenario: decrypting a eyaml file should add a preamble
     Given my EDITOR is set to "/bin/cat"
     When I run `bash -c 'cp test_input.yaml test_input.eyaml'`
@@ -177,3 +183,10 @@ Feature: eyaml editing
     When I run `eyaml edit test_input.eyaml`
     Then the output should match /spaced editor\.sh" -c/
     Then the stderr should contain "No changes detected"
+
+  Scenario: EDITOR is invalid
+    Given my EDITOR is set to "does_not_exist.sh"
+    When I run `bash -c 'cp test_input.yaml test_input.eyaml'`
+    When I run `eyaml edit test_input.eyaml`
+    Then the stderr should contain "Editor did not exit successfully"
+    Then the stderr should not contain "Wrote temporary file"

--- a/lib/hiera/backend/eyaml/subcommands/edit.rb
+++ b/lib/hiera/backend/eyaml/subcommands/edit.rb
@@ -68,15 +68,15 @@ eos
           end
 
           def self.execute
+            editor = Utils.find_editor
+
             encrypted_parser = Parser::ParserFactory.encrypted_parser
             tokens = encrypted_parser.parse Eyaml::Options[:input_data]
             decrypted_input = tokens.each_with_index.to_a.map{|(t,index)| t.to_decrypted :index => index}.join
             decrypted_file_content = Eyaml::Options[:no_preamble] ? decrypted_input : (self.preamble + decrypted_input)
-            decrypted_file = Utils.write_tempfile decrypted_file_content
-
-            editor = Utils.find_editor
 
             begin
+              decrypted_file = Utils.write_tempfile decrypted_file_content unless decrypted_file
               system "#{editor} \"#{decrypted_file}\""
               status = $?
 

--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -75,6 +75,8 @@ class Hiera
           file.puts data_to_write
           file.close
 
+          Utils::debug "Wrote temporary file: #{path}"
+
           path
         end
 

--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -72,6 +72,17 @@ class Hiera
           file.close!
 
           file = File.open(path, "w")
+          file.chmod(0600)
+          if ENV['OS'] == 'Windows_NT'
+            # Windows doesn't support chmod
+            icacls = 'C:\Windows\system32\icacls.exe'
+            if File.executable? icacls
+              current_user = `C:\\Windows\\system32\\whoami.exe`.chomp
+              # Use ACLs to restrict access to the current user only
+              command = %Q{#{icacls} "#{file.path}" /grant:r "#{current_user}":f /inheritance:r}
+              system "#{command} >NUL 2>&1"
+            end
+          end
           file.puts data_to_write
           file.close
 


### PR DESCRIPTION
This pull request ensures that:

1. Editor temp files are not created if there's no suitable editor
2. Editor temp files are only readable by the current user

This pull request depends on #151.

Fixes #149.